### PR TITLE
Connect client when reconnect property in channel /meta/connect is handshake.

### DIFF
--- a/ZetaPushSwift/ClientHelper.swift
+++ b/ZetaPushSwift/ClientHelper.swift
@@ -303,6 +303,10 @@ open class ClientHelper : NSObject, CometdClientDelegate{
         self.connect()
     }
     
+    public func reconnect() {
+        self.connect()
+    }
+    
     open func disconnectedFromServer(_ client: CometdClient) {
         log.debug("ClientHelper Disconnected from Cometd server", userInfo: [tags: "zetapush"])
         self.connected = false;

--- a/ZetaPushSwift/ClientHelper.swift
+++ b/ZetaPushSwift/ClientHelper.swift
@@ -303,7 +303,7 @@ open class ClientHelper : NSObject, CometdClientDelegate{
         self.connect()
     }
     
-    public func reconnect() {
+    public func reconnect(_ client: CometdClient) {
         self.connect()
     }
     

--- a/ZetaPushSwift/CometdClient+Bayeux.swift
+++ b/ZetaPushSwift/CometdClient+Bayeux.swift
@@ -80,7 +80,7 @@ public enum BayeuxAdvice: String {
 public enum BayeuxAdviceReconnect: String {
     case None = "none"
     case Retry = "retry"
-    case Handshae = "handshake"
+    case Handshake = "handshake"
 }
 
 // MARK: Private Bayuex Methods

--- a/ZetaPushSwift/CometdClient+Parsing.swift
+++ b/ZetaPushSwift/CometdClient+Parsing.swift
@@ -57,7 +57,7 @@ extension CometdClient {
                         if (reconnect == BayeuxAdviceReconnect.Handshake.rawValue) {
                             // reconnect client here
                             // cause server reconnect property type, in advice, is 'handshake'
-                            delegate?.reconnect()
+                            delegate?.reconnect(self)
                         } else {
                             self.cometdConnected = false
                             self.transport?.closeConnection()

--- a/ZetaPushSwift/CometdClientDelegate.swift
+++ b/ZetaPushSwift/CometdClientDelegate.swift
@@ -26,6 +26,7 @@ public protocol CometdClientDelegate: NSObjectProtocol {
     func didUnsubscribeFromChannel(_ client:CometdClient, channel:String)
     func subscriptionFailedWithError(_ client:CometdClient, error:subscriptionError)
     func cometdClientError(_ client:CometdClient, error:NSError)
+    func reconnect()
 }
 
 public extension CometdClientDelegate {
@@ -40,5 +41,6 @@ public extension CometdClientDelegate {
     func didUnsubscribeFromChannel(_ client:CometdClient, channel:String){}
     func subscriptionFailedWithError(_ client:CometdClient, error:subscriptionError){}
     func cometdClientError(_ client:CometdClient, error:NSError){}
+    func reconnect(){}
 }
 

--- a/ZetaPushSwift/CometdClientDelegate.swift
+++ b/ZetaPushSwift/CometdClientDelegate.swift
@@ -26,7 +26,7 @@ public protocol CometdClientDelegate: NSObjectProtocol {
     func didUnsubscribeFromChannel(_ client:CometdClient, channel:String)
     func subscriptionFailedWithError(_ client:CometdClient, error:subscriptionError)
     func cometdClientError(_ client:CometdClient, error:NSError)
-    func reconnect()
+    func reconnect(_ client:CometdClient)
 }
 
 public extension CometdClientDelegate {
@@ -41,6 +41,6 @@ public extension CometdClientDelegate {
     func didUnsubscribeFromChannel(_ client:CometdClient, channel:String){}
     func subscriptionFailedWithError(_ client:CometdClient, error:subscriptionError){}
     func cometdClientError(_ client:CometdClient, error:NSError){}
-    func reconnect(){}
+    func reconnect(_ client:CometdClient){}
 }
 


### PR DESCRIPTION
In `parseCometdMessage` when `metaChannel` match with `Connect` type, `successul` property is checked to know if we need to retry or disconnect connection from server. 

For instance, this json will allow retry connection 
```json
{ "advice" : { "timeout" : 30000, "interval" : 0, "reconnect" : "retry" }, "successful" : true, "channel" : "\/meta\/connect" }
```

But if this json occur, we need to reconnect client not disconnect it from server. 
```json
{ "channel" : "\/meta\/connect", "advice" : { "interval" : 0, "reconnect" : "handshake" }, "successful" : false, "error" : "402::Unknown client" }
```