### PR TITLE
WIP: Refact and improvements for batch events implementation

### DIFF
--- a/ZetaPushSwift/ClientHelper.swift
+++ b/ZetaPushSwift/ClientHelper.swift
@@ -145,6 +145,7 @@ open class ClientHelper : NSObject, CometdClientDelegate{
         client.subscribe(models)
     }
     
+    @discardableResult
     open func subscribe(_ channel:String, block:ChannelSubscriptionBlock?=nil) -> Subscription? {
         let (_, sub) = self.cometdClient!.subscribeToChannel(channel, block: block)
         
@@ -292,7 +293,7 @@ open class ClientHelper : NSObject, CometdClientDelegate{
             }
             self.subscriptionQueue.removeAll()
             for sub in tempArray {
-                _ = self.subscribe(sub.channel, block: sub.callback)
+                self.subscribe(sub.channel, block: sub.callback)
             }
         }
         firstHandshakeFlag = false

--- a/ZetaPushSwift/ClientHelper.swift
+++ b/ZetaPushSwift/ClientHelper.swift
@@ -37,7 +37,7 @@ open class ClientHelper : NSObject, CometdClientDelegate{
     var logLevel: XCGLogger.Level = .severe
     
     fileprivate var authentication: AbstractHandshake?
-    var cometdClient: CometdClient?
+    let cometdClient: CometdClient
     
     open weak var delegate:ClientHelperDelegate?
     
@@ -67,7 +67,7 @@ open class ClientHelper : NSObject, CometdClientDelegate{
             }
         }
         
-        self.cometdClient?.delegate = self
+        self.cometdClient.delegate = self
     }
     
     open func setAuthentication(authentication: AbstractHandshake){
@@ -79,11 +79,11 @@ open class ClientHelper : NSObject, CometdClientDelegate{
     }
     
     // Disconnect from server
-    open func disconnect(){
+    open func disconnect() {
         log.debug("ClientHelper disconnect", userInfo: [tags: "zetapush"])
-        self.wasConnected = false;
-        self.connected = false;
-        cometdClient!.disconnectFromServer()
+        self.wasConnected = false
+        self.connected = false
+        cometdClient.disconnectFromServer()
     }
     
     // Connect to server
@@ -113,9 +113,9 @@ open class ClientHelper : NSObject, CometdClientDelegate{
                 self.log.debug("ZetaPush selected Server")
                 self.log.debug(self.server)
                 
-                self.cometdClient?.setLogLevel(logLevel: self.logLevel)
-                self.cometdClient?.configure(url: self.server)
-                self.cometdClient?.connectHandshake(self.authentication!.getHandshakeFields(self))
+                self.cometdClient.setLogLevel(logLevel: self.logLevel)
+                self.cometdClient.configure(url: self.server)
+                self.cometdClient.connectHandshake(self.authentication!.getHandshakeFields(self))
             }
             
             task.resume()
@@ -124,47 +124,43 @@ open class ClientHelper : NSObject, CometdClientDelegate{
         } else {
             log.debug("ZetaPush configured Server", userInfo: [tags: "zetapush"])
             log.debug(self.server, userInfo: [tags: "zetapush"])
-            self.cometdClient?.configure(url: self.server)
-            self.cometdClient?.connectHandshake(self.authentication!.getHandshakeFields(self))
+            self.cometdClient.configure(url: self.server)
+            self.cometdClient.connectHandshake(self.authentication!.getHandshakeFields(self))
         }
         
     }
 
     open func subscribe(_ tuples: [ModelBlockTuple]) {
-        guard let client = self.cometdClient else {
-            return
-        }
         // Convert model to subscription
-        let models = tuples.map(client.mapModelToSubscription).compactMap { (state, _) -> CometdSubscriptionModel? in
-            switch state {
-                case .subscribingTo(let model): return model
-                default: return nil
-            }
-        }
+        let models: [CometdSubscriptionModel] = tuples.map(cometdClient.modelToSubscription)
+            .filter { $0.state.isSubscribingTo }
+            .compactMap { $0.state.model }
         // Batch subscriptions
-        client.subscribe(models)
+        cometdClient.subscribe(models)
     }
     
     @discardableResult
-    open func subscribe(_ channel:String, block:ChannelSubscriptionBlock?=nil) -> Subscription? {
-        let (_, sub) = self.cometdClient!.subscribeToChannel(channel, block: block)
-        
+    open func subscribe(_ channel: String, block: ChannelSubscriptionBlock? = nil) -> Subscription? {
+        let (state, sub) = self.cometdClient.subscribeToChannel(channel, block: block)
         guard sub != nil else {
             self.log.error ("sub is NILLLLLL", userInfo: [tags: "zetapush"])
             self.log.error (channel, userInfo: [tags: "zetapush"])
             return nil
         }
-
+        if case let .subscribingTo(model) = state {
+            // if channel to subscribe is in state = subscribing to we need to launch the subscription of it
+            cometdClient.subscribe(model)
+        }
         return sub
     }
     
     open func publish(_ channel:String, message:[String:AnyObject]) {
-        self.cometdClient!.publish(message, channel: channel)
+        self.cometdClient.publish(message, channel: channel)
     }
     
     open func unsubscribe(_ subscription:Subscription){
         log.debug("ClientHelper unsubscribe", userInfo: [tags: "zetapush"])
-        self.cometdClient!.unsubscribeFromChannel(subscription)
+        self.cometdClient.unsubscribeFromChannel(subscription)
         if let index = self.subscriptionQueue.index(of: subscription){
             self.subscriptionQueue.remove(at: index)
         }
@@ -177,7 +173,7 @@ open class ClientHelper : NSObject, CometdClientDelegate{
     }
     
     open func setForceSecure(_ isSecure: Bool){
-        self.cometdClient!.setForceSecure(isSecure)
+        self.cometdClient.setForceSecure(isSecure)
     }
     
     open func composeServiceChannel(_ verb: String, deploymentId: String) -> String {
@@ -203,7 +199,7 @@ open class ClientHelper : NSObject, CometdClientDelegate{
     func eraseHandshakeToken(){}
     
     open func getClientId() -> String{
-        return self.cometdClient!.getCometdClientId()
+        return self.cometdClient.getCometdClientId()
     }
     
     open func getHandshakeFields() -> [String: AnyObject]{
@@ -231,7 +227,7 @@ open class ClientHelper : NSObject, CometdClientDelegate{
     }
     
     open func isConnected() -> Bool{
-        return self.cometdClient?.isConnected() ?? false
+        return self.cometdClient.isConnected()
     }
     
     open func getPublicToken() -> String{
@@ -255,7 +251,7 @@ open class ClientHelper : NSObject, CometdClientDelegate{
         self.wasConnected = self.connected;
         self.connected = true;
         if (!self.wasConnected && self.connected) {
-            _ = self.cometdClient?.pendingSubscriptionSchedule.isValid
+            _ = self.cometdClient.pendingSubscriptionSchedule.isValid
             self.delegate?.onConnectionEstablished(self);
         }
     }

--- a/ZetaPushSwift/CometdClient+Subscription.swift
+++ b/ZetaPushSwift/CometdClient+Subscription.swift
@@ -16,20 +16,15 @@ extension CometdClient {
     
     func subscribeQueuedSubscriptions() {
         // if there are any outstanding open subscriptions resubscribe
-        for channel in self.queuedSubscriptions {
-            _ = removeChannelFromQueuedSubscriptions(channel.subscriptionUrl)
-            _ = subscribeToChannel(channel)
-        }
+        self.queuedSubscriptions.forEach { removeChannelFromQueuedSubscriptions($0.subscriptionUrl) }
+        self.subscribe(self.queuedSubscriptions)
     }
     
     func resubscribeToPendingSubscriptions() {
         if !pendingSubscriptions.isEmpty {
             log.debug("Cometd: Resubscribing to \(pendingSubscriptions.count) pending subscriptions")
-            
-            for channel in pendingSubscriptions {
-                _ = removeChannelFromPendingSubscriptions(channel.subscriptionUrl)
-                _ = subscribeToChannel(channel)
-            }
+            self.pendingSubscriptions.forEach { removeChannelFromPendingSubscriptions($0.subscriptionUrl) }
+            self.subscribe(self.pendingSubscriptions)
         }
     }
     
@@ -73,6 +68,7 @@ extension CometdClient {
     // MARK:
     // MARK: Subscriptions
     
+    @discardableResult
     func removeChannelFromQueuedSubscriptions(_ channel: String) -> Bool {
         objc_sync_enter(self.queuedSubscriptions)
         defer { objc_sync_exit(self.queuedSubscriptions) }
@@ -88,6 +84,7 @@ extension CometdClient {
         return false
     }
     
+    @discardableResult
     func removeChannelFromPendingSubscriptions(_ channel: String) -> Bool {
         objc_sync_enter(self.pendingSubscriptions)
         defer { objc_sync_exit(self.pendingSubscriptions) }
@@ -103,6 +100,7 @@ extension CometdClient {
         return false
     }
     
+    @discardableResult
     func removeChannelFromOpenSubscriptions(_ channel: String) -> Bool {
         objc_sync_enter(self.pendingSubscriptions)
         defer { objc_sync_exit(self.pendingSubscriptions) }

--- a/ZetaPushSwift/CometdClient+Subscription.swift
+++ b/ZetaPushSwift/CometdClient+Subscription.swift
@@ -53,8 +53,9 @@ extension CometdClient {
     func receive(_ message: String) {
         readOperationQueue.sync { [unowned self] in
             if let jsonData = message.data(using: String.Encoding.utf8, allowLossyConversion: false) {
-                let json = JSON(data: jsonData)
-                self.parseCometdMessage(json.arrayValue)
+                if let json = try? JSON(data: jsonData) {
+                    self.parseCometdMessage(json.arrayValue)
+                }
             }
         }
     }

--- a/ZetaPushSwift/CometdClient+Subscription.swift
+++ b/ZetaPushSwift/CometdClient+Subscription.swift
@@ -53,9 +53,8 @@ extension CometdClient {
     func receive(_ message: String) {
         readOperationQueue.sync { [unowned self] in
             if let jsonData = message.data(using: String.Encoding.utf8, allowLossyConversion: false) {
-                if let json = try? JSON(data: jsonData) {
-                    self.parseCometdMessage(json.arrayValue)
-                }
+                let json = JSON(data: jsonData)
+                self.parseCometdMessage(json.arrayValue)
             }
         }
     }

--- a/ZetaPushSwift/CometdClient.swift
+++ b/ZetaPushSwift/CometdClient.swift
@@ -19,6 +19,28 @@ public enum CometdSubscriptionState {
     case queued(CometdSubscriptionModel)
     case subscribingTo(CometdSubscriptionModel)
     case unknown(CometdSubscriptionModel?)
+    
+    var isSubscribingTo: Bool {
+        switch self {
+        case .subscribingTo:
+            return true
+        default:
+            return false
+        }
+    }
+    
+    var model: CometdSubscriptionModel? {
+        switch self {
+        case .pending(let model),
+             .subscribed(let model),
+             .queued(let model),
+             .subscribingTo(let model),
+             .unknown(let model?):
+            return model
+        default:
+            return nil
+        }
+    }
 }
 
 // MARK: Type Aliases
@@ -162,111 +184,46 @@ open class CometdClient : TransportDelegate {
         }
     }
     
-    open func mapModelToSubscription(tuple: ModelBlockTuple) -> (CometdSubscriptionState, Subscription?) {
+    open func modelToSubscription(tuple: ModelBlockTuple) -> (state: CometdSubscriptionState, subscription: Subscription?) {
         let model = tuple.model
         var sub = Subscription(callback:nil, channel: model.subscriptionUrl, id: 0)
         if let block = tuple.block {
             
-            if self.channelSubscriptionBlocks[model.subscriptionUrl] == nil
-            {
+            if self.channelSubscriptionBlocks[model.subscriptionUrl] == nil {
                 self.channelSubscriptionBlocks[model.subscriptionUrl] = []
             }
-            
             sub.callback = block
             sub.id = self.channelSubscriptionBlocks[model.subscriptionUrl]!.count
             
             self.channelSubscriptionBlocks[model.subscriptionUrl]!.append(sub)
         }
-        // If channel is already subscribed
+        
         if self.isSubscribedToChannel(model.subscriptionUrl) {
+            // If channel is already subscribed
             log.info("CometdClient subscribeToChannel intial subscription")
             return (.subscribed(model), sub)
-        }
-        // If channel is already in pending status
-        if self.pendingSubscriptions.contains(where: { $0 == model }) {
+        } else if self.pendingSubscriptions.contains(where: { $0 == model }) {
+            // If channel is already in pending status
             log.info("CometdClient subscribeToChannel pending subscription")
             return (.pending(model), sub)
-        }
-        // If connection is not yet established
-        if self.cometdConnected == false {
+        } else if self.cometdConnected == false {
+            // If connection is not yet established
             self.queuedSubscriptions.append(model)
             return (.queued(model), sub)
+        } else {
+            return (.subscribingTo(model), sub)
         }
-        return (.subscribingTo(model), sub)
     }
     
-    open func subscribeToChannel(_ model:CometdSubscriptionModel, block:ChannelSubscriptionBlock?=nil) -> (CometdSubscriptionState, Subscription?) {
-        // Initial suscription
-        guard !self.isSubscribedToChannel(model.subscriptionUrl) else {
-            log.info("CometdClient subscribeToChannel intial subscription")
-            var sub = Subscription(callback:nil, channel: model.subscriptionUrl, id: 0)
-            if let block = block {
-                
-                if self.channelSubscriptionBlocks[model.subscriptionUrl] == nil
-                {
-                    self.channelSubscriptionBlocks[model.subscriptionUrl] = []
-                }
-                
-                sub.callback = block
-                sub.id = self.channelSubscriptionBlocks[model.subscriptionUrl]!.count
-                
-                self.channelSubscriptionBlocks[model.subscriptionUrl]!.append(sub)
-            }
-            
-            return (.subscribed(model), sub)
-        }
-        
-        // Additional subscription
-        guard !self.pendingSubscriptions.contains(where: { $0 == model }) else {
-            log.info("CometdClient subscribeToChannel pending subscription")
-            
-            var sub = Subscription(callback:nil, channel: model.subscriptionUrl, id: 0)
-            if let block = block {
-                
-                if self.channelSubscriptionBlocks[model.subscriptionUrl] == nil
-                {
-                    self.channelSubscriptionBlocks[model.subscriptionUrl] = []
-                }
-                
-                sub.callback = block
-                sub.id = self.channelSubscriptionBlocks[model.subscriptionUrl]!.count
-                
-                self.channelSubscriptionBlocks[model.subscriptionUrl]!.append(sub)
-            }
-            
-            return (.pending(model), sub)
-        }
-        
-        var sub = Subscription(callback:nil, channel: model.subscriptionUrl, id: 0)
-        if let block = block {
-        
-            if self.channelSubscriptionBlocks[model.subscriptionUrl] == nil
-            {
-                self.channelSubscriptionBlocks[model.subscriptionUrl] = []
-            }
-        
-            sub.callback = block
-            sub.id = self.channelSubscriptionBlocks[model.subscriptionUrl]!.count
-        
-            self.channelSubscriptionBlocks[model.subscriptionUrl]!.append(sub)
-        }
-        
-        if self.cometdConnected == false {
-            self.queuedSubscriptions.append(model)
-            
-            return (.queued(model), sub)
-        }
-        
-        self.subscribe(model)
-        
-        return (.subscribingTo(model), sub)
+    open func subscribeToChannel(_ channel: String, block: ChannelSubscriptionBlock? = nil) -> (state: CometdSubscriptionState, subscription: Subscription?) {
+        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: cometdClientId)
+        let tuple = ModelBlockTuple(model: model, block: block)
+        return modelToSubscription(tuple: tuple)
     }
     
-    open func subscribeToChannel(_ channel:String, block:ChannelSubscriptionBlock?=nil) -> (CometdSubscriptionState, Subscription?) {
-        return subscribeToChannel(
-            CometdSubscriptionModel(subscriptionUrl: channel, clientId: cometdClientId),
-            block: block
-        )
+    open func subscribeToChannel(_ model: CometdSubscriptionModel, block: ChannelSubscriptionBlock? = nil) -> (state: CometdSubscriptionState, subscription: Subscription?) {
+        let tuple = ModelBlockTuple(model: model, block: block)
+        return modelToSubscription(tuple: tuple)
     }
     
     open func unsubscribeFromChannel(_ subscription:Subscription) {

--- a/ZetaPushSwift/ZetaPushMacroListener.swift
+++ b/ZetaPushSwift/ZetaPushMacroListener.swift
@@ -9,263 +9,197 @@
 import Foundation
 import Gloss
 
-open class ZetaPushMacroListener{
+open class ZetaPushMacroListener {
     
-    public var clientHelper: ClientHelper?
+    public var clientHelper: ClientHelper
     public var zetaPushMacroService: ZetaPushMacroService
     open var onMacroError : ZPMacroServiceErrorBlock?
     
-    public init(_ clientHelper: ClientHelper, deploymentId: String){
+    public init(_ clientHelper: ClientHelper, deploymentId: String) {
         self.clientHelper = clientHelper
         self.zetaPushMacroService = ZetaPushMacroService(clientHelper, deploymentId: deploymentId)
         self.register()
     }
+
     // Must be overriden by descendants
-    open func register(){}
-    
-    public convenience init(_ clientHelper: ClientHelper){
+    open func register() {}
+
+    public convenience init(_ clientHelper: ClientHelper) {
         self.init(clientHelper, deploymentId: zetaPushDefaultConfig.macroDeployementId)
     }
     /**
      
      */
-    public func getModelBlock<T: Glossy>(verb: String, callback: @escaping (T)->Void) -> ModelBlockTuple {
-        let channel = (self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!))!
-        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper?.cometdClient?.cometdClientId)
-        return ModelBlockTuple(model: model, block: {(messageDict: NSDictionary) -> Void in
-            if messageDict.object(forKey: "errors") != nil {
-                if let errors = messageDict["errors"] as? NSArray {
-                    if errors.count > 0 {
-                        if let error = errors[0] as? NSDictionary {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.genericFromDictionnary(error))
-                        } else {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.unknowError)
-                        }
-                    }
-                }
+    public func getModelBlock<T: Glossy>(verb: String, callback: @escaping (T) -> Void) -> ModelBlockTuple {
+        let channel = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!)
+        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient?.cometdClientId)
+        return ModelBlockTuple(model: model, block: { (messageDict: NSDictionary) -> Void in
+
+            self.handleMacroErrors(from: messageDict)
+            guard let zpMessage: T = self.parse(messageDict: messageDict) else {
+                self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.decodingError)
+                return
             }
-            if let result = messageDict["result"] as? NSDictionary {
-                guard let zpMessage = T(json: result as! JSON) else {
-                    self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.decodingError)
-                    return
-                }
-                callback(zpMessage)
-            }
+            callback(zpMessage)
         })
     }
-    public func getModelBlock<T: Glossy>(verb: String, callback: @escaping ([T])->Void) -> ModelBlockTuple {
-        let channel = (self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!))!
-        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper?.cometdClient?.cometdClientId)
+
+    public func getModelBlock<T: Glossy>(verb: String, callback: @escaping ([T]) -> Void) -> ModelBlockTuple {
+        let channel = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!)
+        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient?.cometdClientId)
         return ModelBlockTuple(model: model, block: {(messageDict: NSDictionary) -> Void in
-            if messageDict.object(forKey: "errors") != nil {
-                if let errors = messageDict["errors"] as? NSArray {
-                    if errors.count > 0 {
-                        if let error = errors[0] as? NSDictionary {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.genericFromDictionnary(error))
-                        } else {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.unknowError)
-                        }
-                    }
-                }
+
+            self.handleMacroErrors(from: messageDict)
+            guard let zpMessage: [T] = self.parse(messageDict: messageDict) else {
+                self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.decodingError)
+                return
             }
-            if let result = messageDict["result"] as? NSDictionary {
-                guard let zpMessage = [T].from(jsonArray: result.allKeys as! [JSON]) else {
-                    self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.decodingError)
-                    return
-                }
-                callback(zpMessage)
-            }
+            callback(zpMessage)
         })
     }
-    public func getModelBlock<T: AbstractMacroCompletion>(verb: String, callback: @escaping (T)->Void) -> ModelBlockTuple {
-        let channel = (self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!))!
-        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper?.cometdClient?.cometdClientId)
+
+    public func getModelBlock<T: AbstractMacroCompletion>(verb: String, callback: @escaping (T) -> Void) -> ModelBlockTuple {
+        let channel = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!)
+        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient?.cometdClientId)
         return ModelBlockTuple(model: model, block: {(messageDict: NSDictionary) -> Void in
-            if messageDict.object(forKey: "errors") != nil {
-                if let errors = messageDict["errors"] as? NSArray {
-                    if errors.count > 0 {
-                        if let error = errors[0] as? NSDictionary {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.genericFromDictionnary(error))
-                        } else {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.unknowError)
-                        }
-                    }
-                }
+            
+            self.handleMacroErrors(from: messageDict)
+            guard let zpMessage: T = self.parse(messageDict: messageDict, verb: verb) else {
+                self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.decodingError)
+                return
             }
-            if let result = messageDict["result"] as? NSDictionary {
-                guard let zpMessage = T.resultType(json: result as! JSON) else {
-                    self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.decodingError)
-                    return
-                }
-                let completion = T(result: zpMessage, name: verb, requestId: "")
-                callback(completion)
-            }
+            callback(zpMessage)
         })
     }
-    public func getModelBlock(verb: String, callback: @escaping (NSDictionary)->Void) -> ModelBlockTuple {
-        let channel = (self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!))!
-        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper?.cometdClient?.cometdClientId)
+
+    public func getModelBlock<T: NSDictionary>(verb: String, callback: @escaping (T) -> Void) -> ModelBlockTuple {
+        let channel = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!)
+        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient?.cometdClientId)
         return ModelBlockTuple(model: model, block: {(messageDict: NSDictionary) -> Void in
-            if messageDict.object(forKey: "errors") != nil {
-                if let errors = messageDict["errors"] as? NSArray {
-                    if errors.count > 0 {
-                        if let error = errors[0] as? NSDictionary {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.genericFromDictionnary(error))
-                        } else {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.unknowError)
-                        }
-                    }
-                }
+            
+            self.handleMacroErrors(from: messageDict)
+            guard let zpMessage: T = self.parse(messageDict: messageDict) else {
+                self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.decodingError)
+                return
             }
-            if let result = messageDict["result"] as? NSDictionary {
-                callback(result)
-            }
+            callback(zpMessage)
+
         })
     }
 
     
     public func subscribe(_ tuples: [ModelBlockTuple]) {
-        _ = self.clientHelper?.subscribe(tuples);
+        self.clientHelper.subscribe(tuples);
     }
     
-    /*
-     Generic Subscribe with a Generic parameter
-     */
-    public func subscribe<T: Glossy>(verb: String, callback: @escaping (T)->Void) {
+    /// Generic Subscribe with a Generic parameter
+    public func subscribe<T: Glossy>(verb: String, callback: @escaping (T) -> Void) {
         
         let channelBlockServiceCall:ChannelSubscriptionBlock = {(messageDict) -> Void in
             
-            if messageDict.object(forKey: "errors") != nil {
-                if let errors = messageDict["errors"] as? NSArray {
-                    if errors.count > 0 {
-                        if let error = errors[0] as? NSDictionary {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.genericFromDictionnary(error))
-                        } else {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.unknowError)
-                        }
-                    }
-                }
+            self.handleMacroErrors(from: messageDict)
+            guard let zpMessage: T = self.parse(messageDict: messageDict) else {
+                self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.decodingError)
+                return
             }
-            
-            if let result = messageDict["result"] as? NSDictionary {
-                
-                guard let zpMessage = T(json: result as! JSON) else {
-                    
-                    self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.decodingError)
-                    return
-                }
-                
-                callback(zpMessage)
-            }
-            
+            callback(zpMessage)
         }
-        
-        _ = self.clientHelper?.subscribe((self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!))!, block: channelBlockServiceCall)
+        let channel: String = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!)
+        self.clientHelper.subscribe(channel, block: channelBlockServiceCall)
         
     }
     
-    /*
-     Generic Subscribe with a Generic parameter
-     */
-    public func subscribe<T: AbstractMacroCompletion>(verb: String, callback: @escaping (T)->Void) {
+    /// Generic Subscribe with a Generic parameter
+    public func subscribe<T: AbstractMacroCompletion>(verb: String, callback: @escaping (T) -> Void) {
         
         let channelBlockServiceCall:ChannelSubscriptionBlock = {(messageDict) -> Void in
             
-            if messageDict.object(forKey: "errors") != nil {
-                if let errors = messageDict["errors"] as? NSArray {
-                    if errors.count > 0 {
-                        if let error = errors[0] as? NSDictionary {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.genericFromDictionnary(error))
-                        } else {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.unknowError)
-                        }
-                    }
-                }
+            self.handleMacroErrors(from: messageDict)
+            guard let zpMessage: T = self.parse(messageDict: messageDict, verb: verb) else {
+                self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.decodingError)
+                return
             }
-            
-            if let result = messageDict["result"] as? NSDictionary {
-                
-                guard let zpMessage = T.resultType(json: result as! JSON) else {
-                    
-                    self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.decodingError)
-                    return
-                }
-                
-                let completion = T(result: zpMessage, name: verb, requestId: "")
-                
-                callback(completion)
-            }
-            
+            callback(zpMessage)
         }
-        
-        _ = self.clientHelper?.subscribe((self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!))!, block: channelBlockServiceCall)
+        let channel: String = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!)
+        self.clientHelper.subscribe(channel, block: channelBlockServiceCall)
         
     }
     
-    /*
-     Generic Subscribe with a Generic Array parameter
-     */
-    public func subscribe<T: Glossy>(verb: String, callback: @escaping ([T])->Void) {
-        
+    /// Generic Subscribe with a Generic Array parameter
+    public func subscribe<T: Glossy>(verb: String, callback: @escaping ([T]) -> Void) {
         let channelBlockServiceCall:ChannelSubscriptionBlock = {(messageDict) -> Void in
             
-            if messageDict.object(forKey: "errors") != nil {
-                if let errors = messageDict["errors"] as? NSArray {
-                    if errors.count > 0 {
-                        if let error = errors[0] as? NSDictionary {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.genericFromDictionnary(error))
-                        } else {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.unknowError)
-                        }
-                    }
-                }
+            self.handleMacroErrors(from: messageDict)
+            guard let zpMessage: [T] = self.parse(messageDict: messageDict) else {
+                self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.decodingError)
+                return
             }
-        
-        
-            if let result = messageDict["result"] as? NSDictionary {
-                guard let zpMessage = [T].from(jsonArray: result.allKeys as! [JSON]) else {
-                    
-                    self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.decodingError)
-                    return
-                }
-                
-                callback(zpMessage)
-            }
-            
+            callback(zpMessage)
         }
         
-        _ = self.clientHelper?.subscribe((self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!))!, block: channelBlockServiceCall)
+        let channel: String = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!)
+        self.clientHelper.subscribe(channel, block: channelBlockServiceCall)
         
     }
     
-    /*
-        Generic Subscribe with a NSDictionary parameter
-     */
-    public func subscribe(verb: String, callback: @escaping (NSDictionary)->Void) {
-        
+    /// Generic Subscribe with a NSDictionary parameter
+    public func subscribe<T: NSDictionary>(verb: String, callback: @escaping (T) -> Void) {
         let channelBlockServiceCall:ChannelSubscriptionBlock = {(messageDict) -> Void in
             
-            if messageDict.object(forKey: "errors") != nil {
-                if let errors = messageDict["errors"] as? NSArray {
-                    if errors.count > 0 {
-                        if let error = errors[0] as? NSDictionary {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.genericFromDictionnary(error))
-                        } else {
-                            self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.unknowError)
-                        }
-                    }
-                }
+            self.handleMacroErrors(from: messageDict)
+            guard let zpMessage: T = self.parse(messageDict: messageDict) else {
+                self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.decodingError)
+                return
             }
-            
-            if let result = messageDict["result"] as? NSDictionary {
-                
-                callback(result)
-            }
-            
+            callback(zpMessage)
+
         }
         
-        _ = self.clientHelper?.subscribe((self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!))!, block: channelBlockServiceCall)
+        let channel: String = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!)
+        self.clientHelper.subscribe(channel, block: channelBlockServiceCall)
         
     }
     
+    // MARK: - private funcs
+    private func handleMacroErrors(from messageDict: NSDictionary) {
+        if let errors = messageDict["errors"] as? NSArray, messageDict.object(forKey: "errors") != nil && errors.count > 0 {
+            if let error = errors[0] as? NSDictionary {
+                self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.genericFromDictionnary(error))
+            } else {
+                self.onMacroError?(self.zetaPushMacroService, ZetaPushMacroError.unknowError)
+            }
+        }
+    }
+    
+    private func parse<T: Glossy>(messageDict: NSDictionary) -> T? {
+        guard let result = messageDict["result"] as? NSDictionary,
+            let zpMessage = T(json: result as! JSON) else {
+                return nil
+        }
+        return zpMessage
+    }
+    
+    private func parse<T: Glossy>(messageDict: NSDictionary) -> [T]? {
+        guard let result = messageDict["result"] as? NSDictionary,
+            let zpMessage = [T].from(jsonArray: result.allKeys as! [JSON]) else {
+                return nil
+        }
+        return zpMessage
+    }
+    
+    private func parse<T: AbstractMacroCompletion>(messageDict: NSDictionary, verb: String) -> T? {
+        guard let result = messageDict["result"] as? NSDictionary,
+            let zpMessage = T.resultType(json: result as! JSON) else {
+                return nil
+        }
+        return T(result: zpMessage, name: verb, requestId: "")
+    }
+    
+    private func parse<T: NSDictionary>(messageDict: NSDictionary) -> T? {
+        guard let zpMessage = messageDict["result"] as? T else {
+                return nil
+        }
+        return zpMessage
+    }
 }

--- a/ZetaPushSwift/ZetaPushMacroListener.swift
+++ b/ZetaPushSwift/ZetaPushMacroListener.swift
@@ -11,7 +11,7 @@ import Gloss
 
 open class ZetaPushMacroListener {
     
-    public var clientHelper: ClientHelper
+    public let clientHelper: ClientHelper
     public var zetaPushMacroService: ZetaPushMacroService
     open var onMacroError : ZPMacroServiceErrorBlock?
     
@@ -32,7 +32,7 @@ open class ZetaPushMacroListener {
      */
     public func getModelBlock<T: Glossy>(verb: String, callback: @escaping (T) -> Void) -> ModelBlockTuple {
         let channel = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!)
-        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient?.cometdClientId)
+        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient.cometdClientId)
         return ModelBlockTuple(model: model, block: { (messageDict: NSDictionary) -> Void in
 
             self.handleMacroErrors(from: messageDict)
@@ -46,7 +46,7 @@ open class ZetaPushMacroListener {
 
     public func getModelBlock<T: Glossy>(verb: String, callback: @escaping ([T]) -> Void) -> ModelBlockTuple {
         let channel = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!)
-        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient?.cometdClientId)
+        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient.cometdClientId)
         return ModelBlockTuple(model: model, block: {(messageDict: NSDictionary) -> Void in
 
             self.handleMacroErrors(from: messageDict)
@@ -60,7 +60,7 @@ open class ZetaPushMacroListener {
 
     public func getModelBlock<T: AbstractMacroCompletion>(verb: String, callback: @escaping (T) -> Void) -> ModelBlockTuple {
         let channel = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!)
-        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient?.cometdClientId)
+        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient.cometdClientId)
         return ModelBlockTuple(model: model, block: {(messageDict: NSDictionary) -> Void in
             
             self.handleMacroErrors(from: messageDict)
@@ -74,7 +74,7 @@ open class ZetaPushMacroListener {
 
     public func getModelBlock<T: NSDictionary>(verb: String, callback: @escaping (T) -> Void) -> ModelBlockTuple {
         let channel = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushMacroService.deploymentId!)
-        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient?.cometdClientId)
+        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient.cometdClientId)
         return ModelBlockTuple(model: model, block: {(messageDict: NSDictionary) -> Void in
             
             self.handleMacroErrors(from: messageDict)

--- a/ZetaPushSwift/ZetaPushMacroListener.swift
+++ b/ZetaPushSwift/ZetaPushMacroListener.swift
@@ -89,7 +89,7 @@ open class ZetaPushMacroListener {
 
     
     public func subscribe(_ tuples: [ModelBlockTuple]) {
-        self.clientHelper.subscribe(tuples);
+        self.clientHelper.subscribe(tuples)
     }
     
     /// Generic Subscribe with a Generic parameter

--- a/ZetaPushSwift/ZetaPushMacroService.swift
+++ b/ZetaPushSwift/ZetaPushMacroService.swift
@@ -129,13 +129,13 @@ open class ZetaPushMacroService : NSObject {
         
         // Subscribe to completed macro channel
         self.macroChannel = "/service/" + self.clientHelper!.getSandboxId() + "/" + self.deploymentId! + "/" + "completed"
-        _ = self.clientHelper?.subscribe(self.macroChannel!, block: channelBlockMacroCompleted)
+        self.clientHelper?.subscribe(self.macroChannel!, block: channelBlockMacroCompleted)
         
         self.macroChannelError = "/service/" + self.clientHelper!.getSandboxId() + "/" + self.deploymentId! + "/" + "error"
-        _ = self.clientHelper?.subscribe(self.macroChannelError!, block: channelBlockMacroError)
+        self.clientHelper?.subscribe(self.macroChannelError!, block: channelBlockMacroError)
         
         self.macroChannelTrace = "/service/" + self.clientHelper!.getSandboxId() + "/" + self.deploymentId! + "/" + "trace"
-        _ = self.clientHelper?.subscribe(self.macroChannelTrace!, block: channelBlockMacroTrace)
+        self.clientHelper?.subscribe(self.macroChannelTrace!, block: channelBlockMacroTrace)
         
     }
     

--- a/ZetaPushSwift/ZetaPushServiceListener.swift
+++ b/ZetaPushSwift/ZetaPushServiceListener.swift
@@ -15,105 +15,126 @@ public struct ModelBlockTuple {
 }
 
 open class ZetaPushServiceListener{
-    public var clientHelper: ClientHelper?
+    public var clientHelper: ClientHelper
     var macroChannelError: String
     public var zetaPushService: ZetaPushService
     open var onServiceError: ZPServiceErrorBlock?
     
     // Callback for /error macro channel
-    lazy var channelBlockMacroError:ChannelSubscriptionBlock = {(messageDict) -> Void in
-        
+    lazy var channelBlockMacroError:ChannelSubscriptionBlock = { (messageDict) -> Void in
         self.onServiceError?(self.zetaPushService, ZetaPushServiceError.genericFromDictionnary(messageDict))
     }
     
     // Must be overriden by descendants
-    open func register(){}
+    open func register() {}
     
-    public init(_ clientHelper: ClientHelper, deploymentId: String){
+    public init(_ clientHelper: ClientHelper, deploymentId: String) {
         self.clientHelper = clientHelper
         self.zetaPushService = ZetaPushService(clientHelper, deploymentId: deploymentId)
         
-        self.macroChannelError = "/service/" + self.clientHelper!.getSandboxId() + "/" + deploymentId + "/" + "error"
-        self.clientHelper?.subscribe(self.macroChannelError, block: channelBlockMacroError)
+        self.macroChannelError = "/service/" + self.clientHelper.getSandboxId() + "/" + deploymentId + "/" + "error"
+        self.clientHelper.subscribe(self.macroChannelError, block: channelBlockMacroError)
         
         self.register()
     }
-    /**
-     
-     */
-    public func getModelBlock<T: Glossy>(verb: String, callback: @escaping (T)->Void) -> ModelBlockTuple {
-        let channel = (self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!))!
-        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper?.cometdClient?.cometdClientId)
+    
+    ///
+    public func getModelBlock<T: Glossy>(verb: String, callback: @escaping (T) -> Void) -> ModelBlockTuple {
+        let channel: String = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!)
+        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient?.cometdClientId)
         return ModelBlockTuple(model: model, block: {(messageDict: NSDictionary) -> Void in
-            guard let zpMessage = T(json: messageDict as! JSON) else {
-                
+            guard let zpMessage: T = self.parse(messageDict: messageDict) else {
                 self.onServiceError?(self.zetaPushService, ZetaPushServiceError.decodingError)
                 return
             }
             callback(zpMessage)
         })
     }
-    /**
-     
-     */
-    public func subscribe(_ tuples: [ModelBlockTuple]) {
-        _ = self.clientHelper?.subscribe(tuples);
-    }
-    /*
-     Generic Subscribe with a Generic parameter
-     */
-    public func subscribe<T: Glossy>(verb: String, callback: @escaping (T)->Void) {
-        
-        let channelBlockServiceCall:ChannelSubscriptionBlock = {(messageDict) -> Void in
-            
-            
-            guard let zpMessage = T(json: messageDict as! JSON) else {
-                
+    
+    ///
+    public func getModelBlock<T: Glossy>(verb: String, callback: @escaping ([T]) -> Void) -> ModelBlockTuple {
+        let channel: String = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!)
+        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient?.cometdClientId)
+        return ModelBlockTuple(model: model, block: { (messageDict: NSDictionary) -> Void in
+            guard let zpMessage: [T] = self.parse(messageDict: messageDict) else {
                 self.onServiceError?(self.zetaPushService, ZetaPushServiceError.decodingError)
                 return
             }
-            
             callback(zpMessage)
-            
-        }
-        
-        self.clientHelper?.subscribe((self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!))!, block: channelBlockServiceCall)
-        
-    }
-    /*
-     Generic Subscribe with a Generic Array parameter
-     */
-    public func subscribe<T: Glossy>(verb: String, callback: @escaping ([T])->Void) {
-        
-        let channelBlockServiceCall:ChannelSubscriptionBlock = {(messageDict) -> Void in
-            
-            
-            guard let zpMessage = [T].from(jsonArray: messageDict.allKeys as! [JSON]) else {
-                
-                self.onServiceError?(self.zetaPushService, ZetaPushServiceError.decodingError)
-                return
-            }
-            
-            callback(zpMessage)
-            
-        }
-        
-        self.clientHelper?.subscribe((self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!))!, block: channelBlockServiceCall)
-        
-    }
-    /*
-     Generic Subscribe with a NSDictionary parameter
-     */
-    public func subscribe(verb: String, callback: @escaping (NSDictionary)->Void) {
-        
-        let channelBlockServiceCall:ChannelSubscriptionBlock = {(messageDict) -> Void in
-            
-            callback(messageDict)
-            
-        }
-        
-        self.clientHelper?.subscribe((self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!))!, block: channelBlockServiceCall)
-        
+        })
     }
     
+    ///
+    public func getModelBlock<T: NSDictionary>(verb: String, callback: @escaping (T) -> Void) -> ModelBlockTuple {
+        let channel: String = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!)
+        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient?.cometdClientId)
+        return ModelBlockTuple(model: model, block: { (messageDict: NSDictionary) -> Void in
+            guard let zpMessage: T = self.parse(messageDict: messageDict) else {
+                self.onServiceError?(self.zetaPushService, ZetaPushServiceError.decodingError)
+                return
+            }
+            callback(zpMessage)
+        })
+    }
+    
+    ///
+    public func subscribe(_ tuples: [ModelBlockTuple]) {
+        self.clientHelper.subscribe(tuples)
+    }
+
+    /// Generic Subscribe with a Generic parameter
+    public func subscribe<T: Glossy>(verb: String, callback: @escaping (T) -> Void) {
+        
+        let channelBlockServiceCall: ChannelSubscriptionBlock =  {(messageDict) -> Void in
+            
+            guard let zpMessage: T = self.parse(messageDict: messageDict) else {
+                self.onServiceError?(self.zetaPushService, ZetaPushServiceError.decodingError)
+                return
+            }
+            callback(zpMessage)
+        }
+        let channel: String = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!)
+        self.clientHelper.subscribe(channel, block: channelBlockServiceCall)
+    }
+
+    /// Generic Subscribe with a Generic Array parameter
+    public func subscribe<T: Glossy>(verb: String, callback: @escaping ([T]) -> Void) {
+        
+        let channelBlockServiceCall: ChannelSubscriptionBlock = { (messageDict) -> Void in
+            
+            guard let zpMessage: [T] = self.parse(messageDict: messageDict) else {
+                self.onServiceError?(self.zetaPushService, ZetaPushServiceError.decodingError)
+                return
+            }
+            callback(zpMessage)
+        }
+        let channel: String = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!)
+        self.clientHelper.subscribe(channel, block: channelBlockServiceCall)
+    }
+
+    /// Generic Subscribe with a NSDictionary parameter
+    public func subscribe<T: NSDictionary>(verb: String, callback: @escaping (T) -> Void) {
+        let channelBlockServiceCall: ChannelSubscriptionBlock = { (messageDict) -> Void in
+            guard let zpMessage: T = self.parse(messageDict: messageDict) else {
+                self.onServiceError?(self.zetaPushService, ZetaPushServiceError.decodingError)
+                return
+            }
+            callback(zpMessage)
+        }
+        let channel: String = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!)
+        self.clientHelper.subscribe(channel, block: channelBlockServiceCall)
+    }
+    
+    // MARK: - private funcs
+    private func parse<T: Glossy>(messageDict: NSDictionary) -> T? {
+        return T(json: messageDict as! JSON)
+    }
+    
+    private func parse<T: Glossy>(messageDict: NSDictionary) -> [T]? {
+        return [T].from(jsonArray: messageDict.allKeys as! [JSON])
+    }
+    
+    private func parse<T: NSDictionary>(messageDict: NSDictionary) -> T? {
+        return messageDict as? T
+    }
 }

--- a/ZetaPushSwift/ZetaPushServiceListener.swift
+++ b/ZetaPushSwift/ZetaPushServiceListener.swift
@@ -15,7 +15,7 @@ public struct ModelBlockTuple {
 }
 
 open class ZetaPushServiceListener{
-    public var clientHelper: ClientHelper
+    public let clientHelper: ClientHelper
     var macroChannelError: String
     public var zetaPushService: ZetaPushService
     open var onServiceError: ZPServiceErrorBlock?
@@ -41,7 +41,7 @@ open class ZetaPushServiceListener{
     ///
     public func getModelBlock<T: Glossy>(verb: String, callback: @escaping (T) -> Void) -> ModelBlockTuple {
         let channel: String = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!)
-        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient?.cometdClientId)
+        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient.cometdClientId)
         return ModelBlockTuple(model: model, block: {(messageDict: NSDictionary) -> Void in
             guard let zpMessage: T = self.parse(messageDict: messageDict) else {
                 self.onServiceError?(self.zetaPushService, ZetaPushServiceError.decodingError)
@@ -54,7 +54,7 @@ open class ZetaPushServiceListener{
     ///
     public func getModelBlock<T: Glossy>(verb: String, callback: @escaping ([T]) -> Void) -> ModelBlockTuple {
         let channel: String = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!)
-        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient?.cometdClientId)
+        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient.cometdClientId)
         return ModelBlockTuple(model: model, block: { (messageDict: NSDictionary) -> Void in
             guard let zpMessage: [T] = self.parse(messageDict: messageDict) else {
                 self.onServiceError?(self.zetaPushService, ZetaPushServiceError.decodingError)
@@ -67,7 +67,7 @@ open class ZetaPushServiceListener{
     ///
     public func getModelBlock<T: NSDictionary>(verb: String, callback: @escaping (T) -> Void) -> ModelBlockTuple {
         let channel: String = self.clientHelper.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!)
-        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient?.cometdClientId)
+        let model = CometdSubscriptionModel(subscriptionUrl: channel, clientId: self.clientHelper.cometdClient.cometdClientId)
         return ModelBlockTuple(model: model, block: { (messageDict: NSDictionary) -> Void in
             guard let zpMessage: T = self.parse(messageDict: messageDict) else {
                 self.onServiceError?(self.zetaPushService, ZetaPushServiceError.decodingError)

--- a/ZetaPushSwift/ZetaPushServiceListener.swift
+++ b/ZetaPushSwift/ZetaPushServiceListener.swift
@@ -34,7 +34,7 @@ open class ZetaPushServiceListener{
         self.zetaPushService = ZetaPushService(clientHelper, deploymentId: deploymentId)
         
         self.macroChannelError = "/service/" + self.clientHelper!.getSandboxId() + "/" + deploymentId + "/" + "error"
-        _ = self.clientHelper?.subscribe(self.macroChannelError, block: channelBlockMacroError)
+        self.clientHelper?.subscribe(self.macroChannelError, block: channelBlockMacroError)
         
         self.register()
     }
@@ -77,7 +77,7 @@ open class ZetaPushServiceListener{
             
         }
         
-        _ = self.clientHelper?.subscribe((self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!))!, block: channelBlockServiceCall)
+        self.clientHelper?.subscribe((self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!))!, block: channelBlockServiceCall)
         
     }
     /*
@@ -98,7 +98,7 @@ open class ZetaPushServiceListener{
             
         }
         
-        _ = self.clientHelper?.subscribe((self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!))!, block: channelBlockServiceCall)
+        self.clientHelper?.subscribe((self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!))!, block: channelBlockServiceCall)
         
     }
     /*
@@ -112,7 +112,7 @@ open class ZetaPushServiceListener{
             
         }
         
-        _ = self.clientHelper?.subscribe((self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!))!, block: channelBlockServiceCall)
+        self.clientHelper?.subscribe((self.clientHelper?.composeServiceChannel(verb, deploymentId: self.zetaPushService.deploymentId!))!, block: channelBlockServiceCall)
         
     }
     


### PR DESCRIPTION
I refact and improve (for queued and pending subscriptions) your batch implementation. I am testing this implementation, so is stilll work in progress but in right way. 

In addition we need to change sdk generator to generate an `DeployAsyncApiListener extend ZetaPushMacroListener` that subscribe a list of subscription instead of an individual subscribe for each subscription.